### PR TITLE
Use GPIO degrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chiptool"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/chiptool?rev=28ffa8a19d84914089547f52900ffb5877a5dc23#28ffa8a19d84914089547f52900ffb5877a5dc23"
+source = "git+https://github.com/embassy-rs/chiptool?rev=1d9e0a39a6acc291e50cabc4ed617a87f06d5e89#1d9e0a39a6acc291e50cabc4ed617a87f06d5e89"
 dependencies = [
  "anyhow",
  "clap",
@@ -318,7 +318,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "embassy-cortex-m"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#147609d3bde445b663d0e75c8bccdb152b9c7e1e"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -333,7 +333,7 @@ dependencies = [
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#147609d3bde445b663d0e75c8bccdb152b9c7e1e"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "embassy-sync",
  "embedded-hal 0.2.7",
@@ -345,7 +345,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy#147609d3bde445b663d0e75c8bccdb152b9c7e1e"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -358,12 +358,12 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#147609d3bde445b663d0e75c8bccdb152b9c7e1e"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#147609d3bde445b663d0e75c8bccdb152b9c7e1e"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "num-traits",
 ]
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#147609d3bde445b663d0e75c8bccdb152b9c7e1e"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -382,12 +382,12 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#147609d3bde445b663d0e75c8bccdb152b9c7e1e"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 
 [[package]]
 name = "embassy-stm32"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#147609d3bde445b663d0e75c8bccdb152b9c7e1e"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "bxcan",
@@ -419,7 +419,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#147609d3bde445b663d0e75c8bccdb152b9c7e1e"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "stm32-metapac"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#147609d3bde445b663d0e75c8bccdb152b9c7e1e"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "stm32-metapac-gen"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#147609d3bde445b663d0e75c8bccdb152b9c7e1e"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "chiptool",
  "proc-macro2",

--- a/drivers/scout-st-spin-32/src/bsp/steval_esc002v1.rs
+++ b/drivers/scout-st-spin-32/src/bsp/steval_esc002v1.rs
@@ -1,5 +1,5 @@
 use embassy_stm32::{
-    gpio::{AnyPin, Input, Level, Output, Pin, Pull, Speed},
+    gpio::{Input, Level, Output, Pull, Speed},
     pwm::simple_pwm::SimplePwm,
 };
 
@@ -30,18 +30,18 @@ pub struct Peripherals {
     ///
     /// On the cycle after the low side is disabled, wait for bemf input to go high.
     /// On the cycle after the high side is disabled, wait for the bemf input to go low.
-    pub BEMF_COMPARATOR_1: Input<'static, AnyPin>,
-    pub BEMF_COMPARATOR_2: Input<'static, AnyPin>,
-    pub BEMF_COMPARATOR_3: Input<'static, AnyPin>,
+    pub BEMF_COMPARATOR_1: Input<'static, embassy_stm32::peripherals::PF1>,
+    pub BEMF_COMPARATOR_2: Input<'static, embassy_stm32::peripherals::PF0>,
+    pub BEMF_COMPARATOR_3: Input<'static, embassy_stm32::peripherals::PB1>,
 
     /// High side outputs
     pub hs: SimplePwm<'static, embassy_stm32::peripherals::TIM1>,
     /// Low side output 1
-    pub ls1: Output<'static, AnyPin>,
+    pub ls1: Output<'static, embassy_stm32::peripherals::PB13>,
     /// Low side output 2
-    pub ls2: Output<'static, AnyPin>,
+    pub ls2: Output<'static, embassy_stm32::peripherals::PB14>,
     /// Low side output 3
-    pub ls3: Output<'static, AnyPin>,
+    pub ls3: Output<'static, embassy_stm32::peripherals::PB15>,
 
     // LED control is inverted. Setting the output LOW turns on the LED.
     pub RGB_LED_RED: Output<'static, embassy_stm32::peripherals::PA0>,
@@ -90,9 +90,9 @@ pub fn init() -> Peripherals {
         OC_COMP_INT: p.OC_COMP_INT,
         OC_COMP_INT2: p.OC_COMP_INT2,
 
-        BEMF_COMPARATOR_1: Input::new(p.PF1.degrade(), Pull::None),
-        BEMF_COMPARATOR_2: Input::new(p.PF0.degrade(), Pull::None),
-        BEMF_COMPARATOR_3: Input::new(p.PB1.degrade(), Pull::None),
+        BEMF_COMPARATOR_1: Input::new(p.PF1, Pull::None),
+        BEMF_COMPARATOR_2: Input::new(p.PF0, Pull::None),
+        BEMF_COMPARATOR_3: Input::new(p.PB1, Pull::None),
 
         hs: p.hs,
         ls1: p.ls1,

--- a/drivers/scout-st-spin-32/src/sip.rs
+++ b/drivers/scout-st-spin-32/src/sip.rs
@@ -1,5 +1,5 @@
 use embassy_stm32::{
-    gpio::{AnyPin, Input, Level, Output, Pin, Pull, Speed},
+    gpio::{Input, Level, Output, Pull, Speed},
     pwm::simple_pwm::{PwmPin, SimplePwm},
     time::Hertz,
     Config,
@@ -34,11 +34,11 @@ pub struct Peripherals {
     /// High side outputs
     pub hs: SimplePwm<'static, embassy_stm32::peripherals::TIM1>,
     /// Low side output 1
-    pub ls1: Output<'static, AnyPin>,
+    pub ls1: Output<'static, embassy_stm32::peripherals::PB13>,
     /// Low side output 2
-    pub ls2: Output<'static, AnyPin>,
+    pub ls2: Output<'static, embassy_stm32::peripherals::PB14>,
     /// Low side output 3
-    pub ls3: Output<'static, AnyPin>,
+    pub ls3: Output<'static, embassy_stm32::peripherals::PB15>,
 
     pub ADC: embassy_stm32::peripherals::ADC,
 }
@@ -75,9 +75,9 @@ pub fn init() -> Peripherals {
     let hs1 = PwmPin::new_ch1(p.PA8);
     let hs2 = PwmPin::new_ch2(p.PA9);
     let hs3 = PwmPin::new_ch3(p.PA10);
-    let ls1 = Output::new(p.PB13.degrade(), Level::Low, Speed::VeryHigh);
-    let ls2 = Output::new(p.PB14.degrade(), Level::Low, Speed::VeryHigh);
-    let ls3 = Output::new(p.PB15.degrade(), Level::Low, Speed::VeryHigh);
+    let ls1 = Output::new(p.PB13, Level::Low, Speed::VeryHigh);
+    let ls2 = Output::new(p.PB14, Level::Low, Speed::VeryHigh);
+    let ls3 = Output::new(p.PB15, Level::Low, Speed::VeryHigh);
 
     Peripherals {
         PF0: p.PF0,

--- a/scout-esc/Cargo.lock
+++ b/scout-esc/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chiptool"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/chiptool?rev=28ffa8a19d84914089547f52900ffb5877a5dc23#28ffa8a19d84914089547f52900ffb5877a5dc23"
+source = "git+https://github.com/embassy-rs/chiptool?rev=1d9e0a39a6acc291e50cabc4ed617a87f06d5e89#1d9e0a39a6acc291e50cabc4ed617a87f06d5e89"
 dependencies = [
  "anyhow",
  "clap",
@@ -320,7 +320,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "embassy-cortex-m"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "defmt",
  "embassy-sync",
@@ -350,7 +350,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -365,12 +365,12 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "defmt",
  "num-traits",
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -388,9 +388,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-net-driver"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
 name = "embassy-stm32"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "bxcan",
@@ -404,6 +412,7 @@ dependencies = [
  "embassy-executor",
  "embassy-futures",
  "embassy-hal-common",
+ "embassy-net-driver",
  "embassy-sync",
  "embassy-time",
  "embassy-usb-driver",
@@ -429,7 +438,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -442,7 +451,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -459,7 +468,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "defmt",
 ]
@@ -1068,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "stm32-metapac"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -1079,7 +1088,7 @@ dependencies = [
 [[package]]
 name = "stm32-metapac-gen"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "chiptool",
  "proc-macro2",

--- a/scout-esc/src/main.rs
+++ b/scout-esc/src/main.rs
@@ -60,21 +60,25 @@ async fn main(_spawner: Spawner) {
     let Peripherals {
         mut over_current_protection,
         mut hs,
-        mut ls1,
-        mut ls2,
-        mut ls3,
+        ls1,
+        ls2,
+        ls3,
         BEMF_COMPARATOR_1: bemf_comparator_1,
         BEMF_COMPARATOR_2: bemf_comparator_2,
         BEMF_COMPARATOR_3: bemf_comparator_3,
         ..
     } = scout_st_spin_32::bsp::steval_esc002v1::init();
 
+    let mut ls1 = ls1.degrade();
+    let mut ls2 = ls2.degrade();
+    let mut ls3 = ls3.degrade();
+
     // Safety: These are only read from an interrupt which isn't enabled yet, so
     // they are safe to write to.
     unsafe {
-        BEMF_COMPARATOR_1 = Some(bemf_comparator_1);
-        BEMF_COMPARATOR_2 = Some(bemf_comparator_2);
-        BEMF_COMPARATOR_3 = Some(bemf_comparator_3);
+        BEMF_COMPARATOR_1 = Some(bemf_comparator_1.degrade());
+        BEMF_COMPARATOR_2 = Some(bemf_comparator_2.degrade());
+        BEMF_COMPARATOR_3 = Some(bemf_comparator_3.degrade());
     }
 
     over_current_protection.configure_threshold(OverCurrentThreshold::Amps500);

--- a/scout-fc/Cargo.lock
+++ b/scout-fc/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chiptool"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/chiptool?rev=28ffa8a19d84914089547f52900ffb5877a5dc23#28ffa8a19d84914089547f52900ffb5877a5dc23"
+source = "git+https://github.com/embassy-rs/chiptool?rev=1d9e0a39a6acc291e50cabc4ed617a87f06d5e89#1d9e0a39a6acc291e50cabc4ed617a87f06d5e89"
 dependencies = [
  "anyhow",
  "clap",
@@ -320,7 +320,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "embassy-cortex-m"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "defmt",
  "embassy-sync",
@@ -350,7 +350,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -365,12 +365,12 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "defmt",
  "num-traits",
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -388,9 +388,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-net-driver"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
 name = "embassy-stm32"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "bxcan",
@@ -404,6 +412,7 @@ dependencies = [
  "embassy-executor",
  "embassy-futures",
  "embassy-hal-common",
+ "embassy-net-driver",
  "embassy-sync",
  "embassy-time",
  "embassy-usb-driver",
@@ -429,7 +438,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -442,7 +451,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -459,7 +468,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "defmt",
 ]
@@ -1073,7 +1082,7 @@ dependencies = [
 [[package]]
 name = "stm32-metapac"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -1084,7 +1093,7 @@ dependencies = [
 [[package]]
 name = "stm32-metapac-gen"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#d1dd66cfcacd9a519188d7799d9c045673fff738"
+source = "git+https://github.com/embassy-rs/embassy#662a02a557457f09c4f9b1f5320c657991a65fc6"
 dependencies = [
  "chiptool",
  "proc-macro2",


### PR DESCRIPTION
Update embassy to support gpio degrade to AnyPin, and update the SIP/BSP libraries to take advantage of this. 